### PR TITLE
Only add a parent property to children which can accept it

### DIFF
--- a/esprima-walk.js
+++ b/esprima-walk.js
@@ -57,7 +57,11 @@ walk.walkAddParent = function ( ast, fn ) {
 
 						subchild = child[ j ]
 
-						subchild.parent = node
+						if( subchild instanceof Object ) {
+
+							subchild.parent = node
+
+						}
 
 						stack.push( subchild )
 


### PR DESCRIPTION
When used with the 'loc' settings the esprima output can include plain String or Number children which cannot have a `.parent` property, so it fails. Checking the type of the child and only applying `parent` to Objects avoids this issue.
